### PR TITLE
Update npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,1 @@
-node_modules/
 Example/

--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
         "react-native-root-siblings": "^4.0.0"
     },
     "main": "./lib/Modal.js",
+    "files": [
+        "lib/"
+    ],
     "keywords": [
         "react-component",
         "react-native",


### PR DESCRIPTION
A quick update that adds the `files` field to `package.json` (now the files gitattributes and editorconfig are no longer part of the distributed archive).

Also, there is no need to specify `node_modules/` in `npmignore` (it's ignored by default).